### PR TITLE
typo for privacy md. Changed readme to yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn install
 yarn dev
 
 # build for production with minification
-npm build
+yarn build
 
 # build for production and view the bundle analyzer report
 yarn build --report

--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ To learn more about graphviz please have a look at http://www.graphviz.org/.
 
 ``` bash
 # install dependencies
-npm install
+yarn install
 
 # serve with hot reload at localhost:8080
-npm run dev
+yarn run dev
 
 # build for production with minification
 npm run build
 
 # build for production and view the bundle analyzer report
-npm run build --report
+yarn run build --report
 
 # run unit tests
-npm run unit
+yarn run unit
 
 # run e2e tests
-npm run e2e
+yarn run e2e
 
 # run all tests
-npm test
+yarn test
 ```
 
 For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).

--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ To learn more about graphviz please have a look at http://www.graphviz.org/.
 yarn install
 
 # serve with hot reload at localhost:8080
-yarn run dev
+yarn dev
 
 # build for production with minification
-npm run build
+npm build
 
 # build for production and view the bundle analyzer report
-yarn run build --report
+yarn build --report
 
 # run unit tests
-yarn run unit
+yarn unit
 
 # run e2e tests
-yarn run e2e
+yarn e2e
 
 # run all tests
 yarn test

--- a/src/markdown/privacy.md
+++ b/src/markdown/privacy.md
@@ -36,6 +36,6 @@ The encryption/decryption is handled by an AWS Lambda function so the secrect ke
 ### Data transfer
 Every request is performed with a secure https connection. Encryption details TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, 128-bin key, TLS.
 
-## Glossar
+## Glossary
 - full-access: Read & write access.
 - dot: Text that will be rendered with Graphviz and follows the dot syntax.


### PR DESCRIPTION
Simple fixes for glossary and changing terms from npm to yarn.